### PR TITLE
Marcar en cola

### DIFF
--- a/models/invoice.py
+++ b/models/invoice.py
@@ -358,6 +358,7 @@ version="1.0">
                     inv.sii_result = 'Proceso'
                 else:
                     inv._crear_envio_cesion()
+                    inv.sii_cesion_result = 'EnCola'
                     self.env['sii.cola_envio'].create({
                                                 'doc_ids':[inv.id],
                                                 'model':'account.invoice',


### PR DESCRIPTION
Cuando se crea la cesion de factura, no se marca en cola, haciendo que el botón de enviar, quede disponible y se envie 2 veces